### PR TITLE
Prevent calling Block.getHarvestLevel() with parameter > 15

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -2,4 +2,4 @@ mc_version=1.7.10
 forge_version=10.13.4.1614-1.7.10
 ccl_version=1.1.3.127
 nei_version=1.0.3.+
-mod_version=1.2.1
+mod_version=1.2.2

--- a/src/codechicken/microblock/BlockMicroMaterial.scala
+++ b/src/codechicken/microblock/BlockMicroMaterial.scala
@@ -104,7 +104,8 @@ class BlockMicroMaterial(val block:Block, val meta:Int = 0) extends IMicroMateri
     
     def toolClasses = Seq("axe", "pickaxe", "shovel")
     
-    def getCutterStrength = block.getHarvestLevel(meta)
+    // meta > 15 will throw ArrayIndexOutOfBoundsException
+    def getCutterStrength = block.getHarvestLevel(meta % 16)
     
     def getSound = block.stepSound
 


### PR DESCRIPTION
Possibly related change:
 * https://github.com/GTNewHorizons/ForgeMultipart/commit/ad1ad6da380dbfab949abfc3a4f3dac298941a90

Fix for:
 * GTNewHorizons/GT-New-Horizons-Modpack#8297