### PR TITLE
Can't call getReturnType on fields

### DIFF
--- a/src/main/scala/codechicken/multipart/asm/ASMMixinCompiler.scala
+++ b/src/main/scala/codechicken/multipart/asm/ASMMixinCompiler.scala
@@ -579,7 +579,7 @@ object ASMMixinCompiler
                     })
             }
             else {
-                fields += FieldMixin(sym.name.trim, getReturnType(sym.jDesc).getDescriptor,
+                fields += FieldMixin(sym.name.trim, sym.jDesc,
                     if (fieldAccessors(sym.name.trim).isPrivate) ACC_PRIVATE else ACC_PUBLIC)
             }
         }


### PR DESCRIPTION
All logged uses on GTNH 2..1.1.0 :
[Client thread/DEBUG] [CCL ASM/ForgeMultipart]: jDesc = [Lcodechicken/multipart/TMultiPart;
[Client thread/DEBUG] [CCL ASM/ForgeMultipart]: jDesc = Ljava/util/LinkedList;
[Client thread/DEBUG] [CCL ASM/ForgeMultipart]: jDesc = Z

No one else ever suffered from this ?
