### PR TITLE
Kill invalid dep file.

### DIFF
--- a/src/main/resources/dependencies.info
+++ b/src/main/resources/dependencies.info
@@ -1,6 +1,0 @@
-{
-	"repo": "http://files.minecraftforge.net/maven/codechicken/CodeChickenLib/${mc_version}-${ccl_version}/",
-	"file": "CodeChickenLib-${mc_version}-${ccl_version}-universal.jar",
-	"dev": "CodeChickenLib-${mc_version}-${ccl_version}-dev.jar",
-	"class": "codechicken.lib.asm.ASMHelper"
-}


### PR DESCRIPTION
It's invalid as is (not currently having the vars replaced), and CCL is shipped with the modpack.