### PR TITLE
Revert "Potential Fix to some FMP stuff relating to Redstone parts no…

### DIFF
--- a/src/main/scala/codechicken/multipart/IRedstonePart.scala
+++ b/src/main/scala/codechicken/multipart/IRedstonePart.scala
@@ -276,6 +276,9 @@ object RedstoneInteractions {
     if (fullVanillaBlocks(block))
       return 0x1f
 
+    if (side == 0) // vanilla doesn't handle side 0
+      return if (power) 0x1f else 0
+
     /** so that these can be conducted to from face parts on the other side of
       * the block. Due to vanilla's in adequecy with redstone/logic on walls
       */


### PR DESCRIPTION
Reverts GTNewHorizons/ForgeMultipart#18 as it broke quite some assumptions in a few mods, causing instabilities such as log turbo spam or instant crash when some setups were loaded in memory.