### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/multipart/lang/en_US.lang
+++ b/src/main/resources/assets/multipart/lang/en_US.lang
@@ -6,6 +6,8 @@ item.microblock:sawIron.name=Iron Saw
 item.microblock:sawDiamond.name=Diamond Saw
 item.microblock:stoneRod.name=Stone Rod
 
+item.microblock.name=Microblock
+
 mcr_face.1.name=%s Cover
 mcr_face.1.subset=Cover
 mcr_face.2.name=%s Panel


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.