### PR TITLE
Forward material to shader

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-   
+    compileOnly("com.github.GTNewHorizons:Angelica:1.0.0-beta43:dev")
+
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.18-GTNH:dev")
 }

--- a/src/main/scala/codechicken/microblock/AngelicaCompat.scala
+++ b/src/main/scala/codechicken/microblock/AngelicaCompat.scala
@@ -10,8 +10,7 @@ class AngelicaCompat {
     try {
       if (Tessellator.instance.isInstanceOf[CapturingTessellator])
         Iris.setShaderMaterialOverride(block, meta)
-    }
-    catch {
+    } catch {
       case ex: ClassCastException => Unit
     }
   }
@@ -20,8 +19,7 @@ class AngelicaCompat {
     try {
       if (Tessellator.instance.isInstanceOf[CapturingTessellator])
         Iris.resetShaderMaterialOverride()
-    }
-    catch {
+    } catch {
       case ex: ClassCastException => Unit
     }
   }

--- a/src/main/scala/codechicken/microblock/AngelicaCompat.scala
+++ b/src/main/scala/codechicken/microblock/AngelicaCompat.scala
@@ -1,0 +1,28 @@
+package codechicken.microblock
+
+import com.gtnewhorizon.gtnhlib.client.renderer.CapturingTessellator
+import net.coderbot.iris.Iris
+import net.minecraft.block.Block
+import net.minecraft.client.renderer.Tessellator
+
+class AngelicaCompat {
+  def setShaderMaterialOverride(block: Block, meta: Int) = {
+    try {
+      if (Tessellator.instance.isInstanceOf[CapturingTessellator])
+        Iris.setShaderMaterialOverride(block, meta)
+    }
+    catch {
+      case ex: ClassCastException => Unit
+    }
+  }
+
+  def resetShaderMaterialOverride() = {
+    try {
+      if (Tessellator.instance.isInstanceOf[CapturingTessellator])
+        Iris.resetShaderMaterialOverride()
+    }
+    catch {
+      case ex: ClassCastException => Unit
+    }
+  }
+}

--- a/src/main/scala/codechicken/microblock/BlockMicroMaterial.scala
+++ b/src/main/scala/codechicken/microblock/BlockMicroMaterial.scala
@@ -8,15 +8,11 @@ import cpw.mods.fml.relauncher.Side
 import net.minecraft.item.ItemStack
 import codechicken.lib.vec.{Cuboid6, Vector3}
 import net.minecraft.entity.player.EntityPlayer
-import codechicken.lib.render.{
-  CCRenderPipeline,
-  CCRenderState,
-  ColourMultiplier
-}
-import codechicken.microblock.handler.MicroblockProxy
+import codechicken.lib.render.{CCRenderPipeline, CCRenderState, ColourMultiplier}
+import codechicken.microblock.handler.{MicroblockMod, MicroblockProxy}
 import net.minecraft.entity.Entity
-import codechicken.lib.render.uv.{UVTransformation, MultiIconTransformation}
-import cpw.mods.fml.common.registry.{GameRegistry, GameData}
+import codechicken.lib.render.uv.{MultiIconTransformation, UVTransformation}
+import cpw.mods.fml.common.registry.{GameData, GameRegistry}
 
 import java.util.function.Supplier
 
@@ -54,7 +50,17 @@ object MaterialRenderHelper {
     this
   }
 
-  def render() = builder.render()
+  def blockAndMeta(b: Block, meta: Int) = {
+    if(MicroblockMod.angelicaCompat != null)
+      MicroblockMod.angelicaCompat.setShaderMaterialOverride(b, meta)
+    this
+  }
+
+  def render() = {
+    builder.render()
+    if(MicroblockMod.angelicaCompat != null)
+      MicroblockMod.angelicaCompat.resetShaderMaterialOverride()
+  }
 }
 
 /** Standard micro material class suitable for most blocks.
@@ -92,6 +98,7 @@ class BlockMicroMaterial(val block: Block, val meta: Int = 0)
       .start(pos, pass, icont)
       .blockColour(getColour(pass))
       .lighting()
+      .blockAndMeta(block, meta)
       .render()
   }
 

--- a/src/main/scala/codechicken/microblock/BlockMicroMaterial.scala
+++ b/src/main/scala/codechicken/microblock/BlockMicroMaterial.scala
@@ -8,7 +8,11 @@ import cpw.mods.fml.relauncher.Side
 import net.minecraft.item.ItemStack
 import codechicken.lib.vec.{Cuboid6, Vector3}
 import net.minecraft.entity.player.EntityPlayer
-import codechicken.lib.render.{CCRenderPipeline, CCRenderState, ColourMultiplier}
+import codechicken.lib.render.{
+  CCRenderPipeline,
+  CCRenderState,
+  ColourMultiplier
+}
 import codechicken.microblock.handler.{MicroblockMod, MicroblockProxy}
 import net.minecraft.entity.Entity
 import codechicken.lib.render.uv.{MultiIconTransformation, UVTransformation}
@@ -51,14 +55,14 @@ object MaterialRenderHelper {
   }
 
   def blockAndMeta(b: Block, meta: Int) = {
-    if(MicroblockMod.angelicaCompat != null)
+    if (MicroblockMod.angelicaCompat != null)
       MicroblockMod.angelicaCompat.setShaderMaterialOverride(b, meta)
     this
   }
 
   def render() = {
     builder.render()
-    if(MicroblockMod.angelicaCompat != null)
+    if (MicroblockMod.angelicaCompat != null)
       MicroblockMod.angelicaCompat.resetShaderMaterialOverride()
   }
 }

--- a/src/main/scala/codechicken/microblock/GrassMicroMaterial.scala
+++ b/src/main/scala/codechicken/microblock/GrassMicroMaterial.scala
@@ -26,6 +26,7 @@ class GrassMicroMaterial extends BlockMicroMaterial(Blocks.grass, 0) {
         .start(pos, pass, icont)
         .blockColour(getColour(pass))
         .lighting()
+        .blockAndMeta(block, meta)
         .render()
     else
       MaterialRenderHelper.start(pos, pass, icont).lighting().render()
@@ -35,6 +36,7 @@ class GrassMicroMaterial extends BlockMicroMaterial(Blocks.grass, 0) {
         .start(pos, pass, new UVTranslation(0, bounds.max.y - 1) ++ sideIconT)
         .blockColour(getColour(pass))
         .lighting()
+        .blockAndMeta(block, meta)
         .render()
   }
 }
@@ -48,12 +50,14 @@ class TopMicroMaterial($block: Block, $meta: Int = 0)
         .start(pos, pass, icont)
         .blockColour(getColour(pass))
         .lighting()
+        .blockAndMeta(block, meta)
         .render()
     else
       MaterialRenderHelper
         .start(pos, pass, new UVTranslation(0, bounds.max.y - 1) ++ icont)
         .blockColour(getColour(pass))
         .lighting()
+        .blockAndMeta(block, meta)
         .render()
   }
 }

--- a/src/main/scala/codechicken/microblock/handler/MicroblockMod.scala
+++ b/src/main/scala/codechicken/microblock/handler/MicroblockMod.scala
@@ -5,7 +5,12 @@ import cpw.mods.fml.common.event.FMLInitializationEvent
 import cpw.mods.fml.common.event.FMLPreInitializationEvent
 import cpw.mods.fml.common.Mod.EventHandler
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent
-import codechicken.microblock.{AngelicaCompat, ConfigContent, DefaultContent, MicroMaterialRegistry}
+import codechicken.microblock.{
+  AngelicaCompat,
+  ConfigContent,
+  DefaultContent,
+  MicroMaterialRegistry
+}
 import codechicken.multipart.Tags
 import cpw.mods.fml.common.event.FMLPostInitializationEvent
 import cpw.mods.fml.common.event.FMLInterModComms.IMCEvent

--- a/src/main/scala/codechicken/microblock/handler/MicroblockMod.scala
+++ b/src/main/scala/codechicken/microblock/handler/MicroblockMod.scala
@@ -5,12 +5,11 @@ import cpw.mods.fml.common.event.FMLInitializationEvent
 import cpw.mods.fml.common.event.FMLPreInitializationEvent
 import cpw.mods.fml.common.Mod.EventHandler
 import cpw.mods.fml.common.event.FMLServerAboutToStartEvent
-import codechicken.microblock.MicroMaterialRegistry
-import codechicken.microblock.DefaultContent
+import codechicken.microblock.{AngelicaCompat, ConfigContent, DefaultContent, MicroMaterialRegistry}
 import codechicken.multipart.Tags
 import cpw.mods.fml.common.event.FMLPostInitializationEvent
-import codechicken.microblock.ConfigContent
 import cpw.mods.fml.common.event.FMLInterModComms.IMCEvent
+
 import scala.collection.JavaConversions._
 
 @Mod(
@@ -50,4 +49,6 @@ object MicroblockMod {
   def handleIMC(event: IMCEvent) {
     ConfigContent.handleIMC(event.getMessages)
   }
+
+  var angelicaCompat: AngelicaCompat = null
 }

--- a/src/main/scala/codechicken/microblock/handler/proxies.scala
+++ b/src/main/scala/codechicken/microblock/handler/proxies.scala
@@ -123,6 +123,9 @@ class MicroblockProxy_clientImpl extends MicroblockProxy_serverImpl {
     MicroMaterialRegistry.loadIcons()
     MinecraftForgeClient.registerItemRenderer(itemMicro, ItemMicroPartRenderer)
     PacketCustom.assignHandler(MicroblockCPH.registryChannel, MicroblockCPH)
+
+    if(Loader.isModLoaded("angelica"))
+      MicroblockMod.angelicaCompat = new AngelicaCompat
   }
 
   @SideOnly(Side.CLIENT)

--- a/src/main/scala/codechicken/microblock/handler/proxies.scala
+++ b/src/main/scala/codechicken/microblock/handler/proxies.scala
@@ -124,7 +124,7 @@ class MicroblockProxy_clientImpl extends MicroblockProxy_serverImpl {
     MinecraftForgeClient.registerItemRenderer(itemMicro, ItemMicroPartRenderer)
     PacketCustom.assignHandler(MicroblockCPH.registryChannel, MicroblockCPH)
 
-    if(Loader.isModLoaded("angelica"))
+    if (Loader.isModLoaded("angelica"))
       MicroblockMod.angelicaCompat = new AngelicaCompat
   }
 


### PR DESCRIPTION
This makes the renderer forward the underlying block id to the shader engine (if shaders are used). This makes crafted microblocks behave more like the blocks they are created from in terms of glow/emissiveness, reflectiveness and more.

![image](https://github.com/user-attachments/assets/b474ba0b-f7a4-4061-9147-0ce4865fb56a)

One thing to note is that `AngelicaCompat` is currently a bit overprotective with type checks and try..catch blocks. This is because Angelica currently assumes that we are rendering terrain when we try passing on the block/meta, but FMB uses the same rendering for world, inventory and preview, and the latter two will not be rendered with the CapturingTesselator. If a check is added to Angelica, this can be simplified here.