### PR TITLE
[Memory-opti:fix leak] Fix WorldClient leak

### DIFF
--- a/src/main/scala/codechicken/multipart/MultipartHelper.scala
+++ b/src/main/scala/codechicken/multipart/MultipartHelper.scala
@@ -41,7 +41,6 @@ object MultipartHelper {
     if (!tag.getString("id").equals("savedMultipart"))
       return null
 
-    MultipartSaveLoad.loadingWorld = world
     return TileMultipart.createFromNBT(tag)
   }
 

--- a/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
@@ -12,11 +12,9 @@ import scala.collection.mutable
 import codechicken.multipart.MultipartHelper.IPartTileConverter
 import scala.collection.JavaConversions._
 
-/** Hack due to lack of TileEntityLoadEvent in forge
-  */
+/** Hack due to lack of TileEntityLoadEvent in forge */
 object MultipartSaveLoad {
   val converters = mutable.MutableList[IPartTileConverter[_]]()
-  var loadingWorld: World = _
 
   class TileNBTContainer extends TileEntity {
     var tag: NBTTagCompound = _
@@ -59,7 +57,6 @@ object MultipartSaveLoad {
   }
 
   def loadTiles(chunk: Chunk) {
-    loadingWorld = chunk.worldObj
     val iterator = chunk.chunkTileEntityMap
       .asInstanceOf[Map[ChunkPosition, TileEntity]]
       .entrySet

--- a/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
@@ -7,7 +7,6 @@ import net.minecraft.world.chunk.Chunk
 import net.minecraft.world.ChunkPosition
 import codechicken.multipart.{MultipartHelper, TileMultipart}
 import codechicken.lib.asm.ObfMapping
-import net.minecraft.world.World
 import scala.collection.mutable
 import codechicken.multipart.MultipartHelper.IPartTileConverter
 import scala.collection.JavaConversions._


### PR DESCRIPTION
This field keeps a reference to the world object but is never accessed, I just deleted it
![image](https://github.com/user-attachments/assets/e8345d47-e153-4d21-8fd4-8897e64dd926)
