### PR TITLE
Force render return type to Unit

### DIFF
--- a/src/main/scala/codechicken/microblock/BlockMicroMaterial.scala
+++ b/src/main/scala/codechicken/microblock/BlockMicroMaterial.scala
@@ -60,7 +60,7 @@ object MaterialRenderHelper {
     this
   }
 
-  def render() = {
+  def render(): Unit = {
     builder.render()
     if (MicroblockMod.angelicaCompat != null)
       MicroblockMod.angelicaCompat.resetShaderMaterialOverride()


### PR DESCRIPTION
Was changed in #27 and was causing crashes with EXU colored blocks