### PR TITLE
Improve performances of microblocks

### DIFF
--- a/src/main/scala/codechicken/microblock/MicroblockRender.scala
+++ b/src/main/scala/codechicken/microblock/MicroblockRender.scala
@@ -7,6 +7,7 @@ import org.lwjgl.opengl.GL11._
 import codechicken.lib.render.{CCRenderState, TextureUtils}
 import codechicken.lib.render.BlockRenderer.BlockFace
 import codechicken.microblock.MicroMaterialRegistry.IMicroMaterial
+
 import java.util.function.Supplier
 
 object MicroblockRender {
@@ -68,9 +69,12 @@ object MicroblockRender {
   ) {
     val localFace = face.get()
     CCRenderState.instance().setModelInstance(localFace)
-    for (s <- 0 until 6 if (faces & 1 << s) == 0) {
-      localFace.loadCuboidFace(c, s)
-      mat.renderMicroFace(pos, pass, c)
+
+    for (s <- 0 until 6) {
+      if ((faces & 1 << s) == 0) {
+        localFace.loadCuboidFace(c, s)
+        mat.renderMicroFace(pos, pass, c)
+      }
     }
   }
 }

--- a/src/main/scala/codechicken/multipart/BlockMultipart.scala
+++ b/src/main/scala/codechicken/multipart/BlockMultipart.scala
@@ -305,10 +305,7 @@ class BlockMultipart extends Block(Material.rock) {
   }
 
   override def getLightValue(world: IBlockAccess, x: Int, y: Int, z: Int): Int =
-    getTile(world, x, y, z) match {
-      case null => 0
-      case tile => tile.getLightValue
-    }
+    world.getBlockMetadata(x, y, z)
 
   override def randomDisplayTick(
       world: World,

--- a/src/main/scala/codechicken/multipart/MultipartRenderer.scala
+++ b/src/main/scala/codechicken/multipart/MultipartRenderer.scala
@@ -25,6 +25,10 @@ object MultipartRenderer
   TileMultipart.renderID = RenderingRegistry.getNextAvailableRenderId
   var pass: Int = 0
 
+  private val cachedPos = new ThreadLocal[Vector3] {
+    override def initialValue() = new Vector3()
+  }
+
   override def renderTileEntityAt(
       t: TileEntity,
       x: Double,
@@ -41,7 +45,9 @@ object MultipartRenderer
     state.pullLightmapInstance()
     state.useNormals = true
 
-    val pos = new Vector3(x, y, z)
+    val pos = cachedPos.get()
+    pos.set(x, y, z)
+
     tmpart.renderDynamic(pos, f, pass)
   }
 

--- a/src/main/scala/codechicken/multipart/MultipartRenderer.scala
+++ b/src/main/scala/codechicken/multipart/MultipartRenderer.scala
@@ -37,8 +37,7 @@ object MultipartRenderer
       f: Float
   ) {
     val tmpart = t.asInstanceOf[TileMultipartClient]
-    if (tmpart.partList.isEmpty)
-      return
+    if (tmpart.partList.isEmpty || !tmpart.hasDynamicParts) return
 
     val state = CCRenderState.instance
     state.resetInstance()

--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -65,6 +65,8 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
     }
   }
 
+  def getBaseRenderDistanceSquared: Double = super.getMaxRenderDistanceSquared
+
   /** Overidden in TSlottedTile when a part that goes in a slot is added
     */
   def partMap(slot: Int): TMultiPart = null
@@ -564,6 +566,11 @@ trait TileMultipartClient extends TileMultipart {
         zCoord + 1
       )
     }
+  }
+
+  override def getMaxRenderDistanceSquared: Double = {
+    if (staticCache == null) updateRenderCache()
+    if (hasDynamicParts) getBaseRenderDistanceSquared else 0.0
   }
 
   override def shouldRenderInPass(pass: Int) = {

--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -385,6 +385,7 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
     */
   def clearParts() {
     partList = Seq()
+    cachedLightValue = 0
   }
 
   /** Writes the description of this tile, and all parts composing it, to packet

--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -167,6 +167,9 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
   def getLightValue: Int = cachedLightValue
 
   private def recalculateLightValue(): Unit = {
+    if (partList.isEmpty)
+      return
+
     cachedLightValue = partList.view.map(_.getLightValue).max
   }
 


### PR DESCRIPTION
Apply multiple optimizations, resulting in significant FPS gain and less memory allocation burden.

Reduction of 

### Optimizations:
- Caching of lightValue
- Caching of AABB
- Caching some Vector3
- Do not re-render TE which are static
- Do not render faces against full blocks
- Cache static and dynamic Parts


### Some data

#### Frames Per Seconds
| Situation | FPS Before | FPS After | Effect |
| ------------- | ------------- | ------------- | --- |
| 1 Room  | ~350 | ~800 | **228% more fps**
| 24 Rooms | ~50  | ~300 | **600% more fps**

