### PR TITLE
Optimize FMP Rendering and memory leaks

### DIFF
--- a/src/main/scala/codechicken/multipart/BlockMultipart.scala
+++ b/src/main/scala/codechicken/multipart/BlockMultipart.scala
@@ -305,10 +305,7 @@ class BlockMultipart extends Block(Material.rock) {
   }
 
   override def getLightValue(world: IBlockAccess, x: Int, y: Int, z: Int): Int =
-    getTile(world, x, y, z) match {
-      case null => 0
-      case tile => tile.getLightValue
-    }
+    world.getBlockMetadata(x, y, z)
 
   override def randomDisplayTick(
       world: World,

--- a/src/main/scala/codechicken/multipart/MultipartRenderer.scala
+++ b/src/main/scala/codechicken/multipart/MultipartRenderer.scala
@@ -33,7 +33,7 @@ object MultipartRenderer
       f: Float
   ) {
     val tmpart = t.asInstanceOf[TileMultipartClient]
-    if (tmpart.partList.isEmpty)
+    if (tmpart.partList.isEmpty | !tmpart.hasDynamicParts)
       return
 
     val state = CCRenderState.instance

--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -385,6 +385,7 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
     */
   def clearParts() {
     partList = Seq()
+    cachedLightValue = 0
   }
 
   /** Writes the description of this tile, and all parts composing it, to packet

--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -1,10 +1,12 @@
 package codechicken.multipart
 
 import net.minecraft.tileentity.TileEntity
+
 import scala.collection.mutable.ListBuffer
 import codechicken.lib.packet.PacketCustom
-import codechicken.lib.vec.{Cuboid6, BlockCoord, Vector3}
+import codechicken.lib.vec.{BlockCoord, Cuboid6, Vector3}
 import net.minecraft.world.World
+
 import java.util.List
 import net.minecraft.nbt.NBTTagCompound
 import codechicken.lib.data.MCDataOutput
@@ -15,16 +17,20 @@ import codechicken.multipart.handler.{
 }
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagList
+
 import java.util.Random
 import net.minecraft.entity.item.EntityItem
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.entity.Entity
+
 import scala.collection.JavaConversions._
 import java.util.Collection
 import codechicken.lib.raytracer.ExtendedMOP
-import net.minecraft.util.Vec3
+import net.minecraft.util.{AxisAlignedBB, Vec3}
+
 import java.lang.Iterable
 import codechicken.lib.world.IChunkLoadTile
+import net.minecraft.block.Block
 
 class TileMultipart extends TileEntity with IChunkLoadTile {
 
@@ -166,8 +172,48 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
 
   def getLightValue: Int = cachedLightValue
 
-  private def recalculateLightValue(): Unit = {
-    cachedLightValue = partList.view.map(_.getLightValue).max
+  override def shouldRefresh(
+      oldBlock: Block,
+      newBlock: Block,
+      oldMeta: Int,
+      newMeta: Int,
+      world: World,
+      x: Int,
+      y: Int,
+      z: Int
+  ): Boolean = {
+    oldBlock != newBlock
+  }
+
+  private def updateLight(): Unit = {
+    if (partList.isEmpty) {
+      cachedLightValue = 0
+      return
+    }
+
+    var max = 0
+    val it = partList.iterator
+    while (it.hasNext) {
+      val l = it.next().getLightValue
+      if (l > max) max = l
+    }
+    cachedLightValue = max
+
+    if (
+      worldObj != null && worldObj.getBlockMetadata(
+        xCoord,
+        yCoord,
+        zCoord
+      ) != cachedLightValue
+    ) {
+      worldObj.setBlockMetadataWithNotify(
+        xCoord,
+        yCoord,
+        zCoord,
+        cachedLightValue,
+        3
+      )
+    }
   }
 
   def getExplosionResistance(entity: Entity) =
@@ -349,7 +395,7 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
     part.tile = null
 
     if (removedLightValue == cachedLightValue && removedLightValue > 0) {
-      recalculateLightValue()
+      updateLight()
     }
 
     if (partList.isEmpty) {
@@ -373,6 +419,9 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
   private[multipart] def loadParts(parts: scala.Iterable[TMultiPart]) {
     clearParts()
     parts.foreach(p => addPart_do(p))
+
+    updateLight()
+
     if (worldObj != null) {
       if (worldObj.isRemote)
         operate(_.onWorldJoin())
@@ -466,24 +515,103 @@ class TileMultipart extends TileEntity with IChunkLoadTile {
 }
 
 trait TileMultipartClient extends TileMultipart {
-  def renderStatic(pos: Vector3, pass: Int) =
-    partList.foldLeft(false)((r, part) => part.renderStatic(pos, pass) || r)
+  private var cachedRenderBounds: AxisAlignedBB = null
+  private var staticCache: Array[TMultiPart] = null
+  private var dynamicCache: Array[TMultiPart] = null
+
+  var hasDynamicParts: Boolean = false
+
+  def updateRenderCache() {
+    if (partList != null) {
+      val (dynamic, static) = partList.partition(_.doesTick)
+      val sArr = static.toArray
+      val dArr = dynamic.toArray
+
+      var c: Cuboid6 = null
+      var i = 0
+      val allParts = sArr ++ dArr
+      while (i < allParts.length) {
+        val b = allParts(i).getRenderBounds
+        if (c == null) c = b.copy
+        else c.enclose(b)
+        i += 1
+      }
+
+      if (c == null) c = Cuboid6.full
+
+      c.add(Vector3.fromTileEntity(this))
+      cachedRenderBounds = c.toAABB
+      staticCache = sArr
+      dynamicCache = dArr
+      hasDynamicParts = dArr.length > 0
+    } else {
+      staticCache = Array.empty
+      dynamicCache = Array.empty
+      hasDynamicParts = false
+      cachedRenderBounds = AxisAlignedBB.getBoundingBox(
+        xCoord,
+        yCoord,
+        zCoord,
+        xCoord + 1,
+        yCoord + 1,
+        zCoord + 1
+      )
+    }
+  }
+
+  def renderStatic(pos: Vector3, pass: Int) = {
+    if (staticCache == null) updateRenderCache()
+    var rendered = false
+
+    val statics = staticCache
+    if (statics != null) {
+      var i = 0
+      val len = statics.length
+      while (i < len) {
+        if (statics(i) != null && statics(i).renderStatic(pos, pass))
+          rendered = true
+        i += 1
+      }
+    }
+
+    val dynamics = dynamicCache
+    if (dynamics != null) {
+      var i = 0
+      val len = dynamics.length
+      while (i < len) {
+        if (dynamics(i) != null && dynamics(i).renderStatic(pos, pass))
+          rendered = true
+        i += 1
+      }
+    }
+    rendered
+  }
 
   def renderDynamic(pos: Vector3, frame: Float, pass: Int) {
-    partList.foreach(part => part.renderDynamic(pos, frame, pass: Int))
+    if (!hasDynamicParts) return
+
+    val dynamics = dynamicCache
+    if (dynamics != null) {
+      var i = 0
+      val len = dynamics.length
+      while (i < len) {
+        if (dynamics(i) != null) dynamics(i).renderDynamic(pos, frame, pass)
+        i += 1
+      }
+    }
   }
 
   def randomDisplayTick(random: Random) {}
 
   override def shouldRenderInPass(pass: Int) = {
     MultipartRenderer.pass = pass
-    true
+    if (staticCache == null) updateRenderCache()
+    hasDynamicParts
   }
 
   override def getRenderBoundingBox = {
-    val c = Cuboid6.full.copy
-    partList.foreach(part => c.enclose(part.getRenderBounds))
-    c.add(Vector3.fromTileEntity(this)).toAABB
+    if (cachedRenderBounds == null) updateRenderCache()
+    cachedRenderBounds
   }
 }
 

--- a/src/main/scala/codechicken/multipart/TileMultipart.scala
+++ b/src/main/scala/codechicken/multipart/TileMultipart.scala
@@ -613,6 +613,11 @@ trait TileMultipartClient extends TileMultipart {
     if (cachedRenderBounds == null) updateRenderCache()
     cachedRenderBounds
   }
+
+  override def markRender(): Unit = {
+    super.markRender()
+    updateRenderCache()
+  }
 }
 
 /** Static class with multipart manipulation helper functions


### PR DESCRIPTION
Apply multiple optimizations, resulting in significant FPS gain and less memory allocation burden.

### Optimizations:
- Caching of lightValue
- Caching of render bounds
- Do not re-render TE which are static
- Cache static and dynamic Parts


### Some data

Did some tests looking at rooms with 1439 pieces of microblocks

#### Frames Per Seconds
| Situation | FPS Before | FPS After | Effect |
| ------------- | ------------- | ------------- | --- |
| 1 Room  | ~350 | ~950 | **+171% more fps**
| 24 Rooms | ~50  | ~450 | **+800% more fps**

