### PR TITLE
[Memory-opti:fix leak] fix world client leak in renderer

### DIFF
--- a/src/main/scala/codechicken/multipart/MultipartRenderer.scala
+++ b/src/main/scala/codechicken/multipart/MultipartRenderer.scala
@@ -85,7 +85,9 @@ object MultipartRenderer
     val state = CCRenderState.instance
     state.resetInstance()
     state.lightMatrix.locate(world, x, y, z)
-    return tmpart.renderStatic(new Vector3(x, y, z), pass)
+    val b = tmpart.renderStatic(new Vector3(x, y, z), pass)
+    state.lightMatrix.access = null
+    b
   }
 
   override def renderInventoryBlock(


### PR DESCRIPTION
<img width="469" height="144" alt="image" src="https://github.com/user-attachments/assets/3e097826-4241-459a-8771-2833349cd32e" />
