### PR TITLE
fix npe on chunk unload when tile is null

### DIFF
--- a/src/main/scala/codechicken/multipart/TMultiPart.scala
+++ b/src/main/scala/codechicken/multipart/TMultiPart.scala
@@ -252,7 +252,9 @@ abstract class TMultiPart {
     * Incremental changes should be sent rather than the whole description
     * packet if possible.
     */
-  def sendDescUpdate() = writeDesc(getWriteStream)
+  def sendDescUpdate() {
+    if (tile != null) writeDesc(getWriteStream)
+  }
 
   /** Called when a part is added or removed from this block space. The part
     * parameter may be null if several things have changed.


### PR DESCRIPTION
sendDescUpdate could run after a part tile is gone during chunk unload and npe in getWriteStream, so skip it when tile is null, needs the wireless redstone guard too


related crash log : 

```
java.lang.NullPointerException: Cannot invoke "codechicken.multipart.TileMultipart.getWriteStream(codechicken.multipart.TMultiPart)" because the return value of "codechicken.multipart.TMultiPart.tile()" is null
	at Launch//codechicken.multipart.TMultiPart.getWriteStream(TMultiPart.scala:238)
	at Launch//codechicken.multipart.TMultiPart.sendDescUpdate(TMultiPart.scala:255)
	at Launch//codechicken.wirelessredstone.logic.WirelessPart.updateChange(WirelessPart.java:204)
	at Launch//codechicken.wirelessredstone.logic.ReceiverPart.setActive(ReceiverPart.java:41)
	at Launch//TTileReceiver$$PassThrough$class.setActive(Unknown Source)
	at Launch//TileMultipart_cmp$$6.setActive(Unknown Source)
	at Launch//codechicken.wirelessredstone.core.RedstoneEtherFrequency.updateReceiver(RedstoneEtherFrequency.java:203)
	at Launch//codechicken.wirelessredstone.core.RedstoneEtherFrequency.updateAllReceivers(RedstoneEtherFrequency.java:182)
	at Launch//codechicken.wirelessredstone.core.RedstoneEtherFrequency.setActiveTransmittersInDim(RedstoneEtherFrequency.java:310)
	at Launch//codechicken.wirelessredstone.core.RedstoneEtherFrequency.decrementActiveTransmitters(RedstoneEtherFrequency.java:170)
	at Launch//codechicken.wirelessredstone.core.RedstoneEtherFrequency.remTransmitter(RedstoneEtherFrequency.java:115)
	at Launch//codechicken.wirelessredstone.core.RedstoneEtherServer.remTransmitter(RedstoneEtherServer.java:131)
	at Launch//codechicken.wirelessredstone.logic.TransmitterPart.removeFromEther(TransmitterPart.java:120)
	at Launch//codechicken.wirelessredstone.logic.WirelessPart.onWorldSeparate(WirelessPart.java:163)
	at Launch//codechicken.multipart.TMultiPart.onChunkUnload(TMultiPart.scala:280)
	at Launch//codechicken.multipart.TileMultipart$$anonfun$onChunkUnload$1.apply(TileMultipart.scala:88)
	at Launch//codechicken.multipart.TileMultipart$$anonfun$onChunkUnload$1.apply(TileMultipart.scala:88)
	at Launch//codechicken.multipart.TileMultipart.operate(TileMultipart.scala:79)
	at Launch//codechicken.multipart.TileMultipart.onChunkUnload(TileMultipart.scala:88)
	at Launch//net.minecraft.world.World.func_72939_s(World.java:1979)
	at Launch//net.minecraft.world.WorldServer.mixinextras$bridge$func_72939_s$80(WorldServer.java)
	at Launch//net.minecraft.world.WorldServer.wrapOperation$zop000$hodgepodge_2$hodgepodge$onUpdateEntities(WorldServer.java:5668)
	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)

```
