### PR TITLE
fix(microblock): prevent microblocks becoming blood rune slabs 

### DIFF
--- a/src/main/scala/codechicken/microblock/DefaultContent.scala
+++ b/src/main/scala/codechicken/microblock/DefaultContent.scala
@@ -54,5 +54,7 @@ object DefaultContent {
     registerMaterial(new GrassMicroMaterial, materialKey(grass))
     MicroMaterialRegistry.remapName(oldKey(mycelium), materialKey(mycelium))
     registerMaterial(new TopMicroMaterial(mycelium), materialKey(mycelium))
+
+    registerMaterial(MissingMicroMaterial, MissingMicroMaterial.key)
   }
 }

--- a/src/main/scala/codechicken/microblock/ItemMicroPart.scala
+++ b/src/main/scala/codechicken/microblock/ItemMicroPart.scala
@@ -133,15 +133,18 @@ object ItemMicroPart {
     if (!stack.getTagCompound.hasKey("mat"))
       return null
 
-    return MicroMaterialRegistry.getMaterial(
+    MicroMaterialRegistry.getMaterial(
       stack.getTagCompound.getString("mat")
-    )
+    ) match {
+      case null => MissingMicroMaterial
+      case mat  => mat
+    }
   }
 
   def getMaterialID(stack: ItemStack): Int = {
     checkTagCompound(stack)
     if (!stack.getTagCompound.hasKey("mat"))
-      return 0
+      return MicroMaterialRegistry.getMissingId
 
     return MicroMaterialRegistry.materialID(
       stack.getTagCompound.getString("mat")

--- a/src/main/scala/codechicken/microblock/MicroMaterialRegistry.scala
+++ b/src/main/scala/codechicken/microblock/MicroMaterialRegistry.scala
@@ -114,6 +114,7 @@ object MicroMaterialRegistry {
   private var maxCuttingStrength: Int = _
 
   private val remap = HashMap[String, String]()
+  private var missingId: Int = 0
 
   /** Register a micro material with unique identifier name
     */
@@ -162,7 +163,16 @@ object MicroMaterialRegistry {
     nameMap.clear()
     for (i <- 0 until idMap.length)
       nameMap.put(idMap(i)._1, i)
+    missingId = nameMap.getOrElse(
+      MissingMicroMaterial.key,
+      throw new IllegalStateException(
+        "MissingMicroMaterial is not registered; the placeholder must never " +
+          "fall back to id 0."
+      )
+    )
   }
+
+  def getMissingId = missingId
 
   private[microblock] def calcMaxCuttingStrength() {
     val it = Item.itemRegistry.iterator.asInstanceOf[JIterator[Item]]
@@ -216,7 +226,7 @@ object MicroMaterialRegistry {
       case Some(v) => v
       case None =>
         logger.error("Missing mapping for part with ID: " + name)
-        0
+        missingId
     }
 
   def getMaterial(name: String) =

--- a/src/main/scala/codechicken/microblock/MissingMicroMaterial.scala
+++ b/src/main/scala/codechicken/microblock/MissingMicroMaterial.scala
@@ -1,0 +1,55 @@
+package codechicken.microblock
+
+import codechicken.lib.render.uv.IconTransformation
+import codechicken.lib.vec.{Cuboid6, Vector3}
+import codechicken.microblock.MicroMaterialRegistry.IMicroMaterial
+import codechicken.microblock.handler.MicroblockProxy
+import cpw.mods.fml.relauncher.{Side, SideOnly}
+import net.minecraft.block.Block
+import net.minecraft.block.Block.SoundType
+import net.minecraft.entity.Entity
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.init.Blocks
+import net.minecraft.item.ItemStack
+import net.minecraft.util.IIcon
+
+/** Stand-in for a material whose name could not be resolved at load time.
+  * Renders the vanilla missing texture (magenta/black checkerboard) and behaves
+  * inertly. Resolving an unknown name to this placeholder keeps microblocks
+  * from silently becoming material id 0 (Blood Rune in GTNH).
+  */
+object MissingMicroMaterial extends IMicroMaterial {
+  val key = "forgemicroblock:missing"
+
+  @SideOnly(Side.CLIENT)
+  private var icon: IIcon = _
+
+  @SideOnly(Side.CLIENT)
+  override def loadIcons(): Unit = {
+    icon = MicroblockProxy.renderBlocks.getIconSafe(null)
+  }
+
+  @SideOnly(Side.CLIENT)
+  override def getBreakingIcon(side: Int): IIcon = icon
+
+  @SideOnly(Side.CLIENT)
+  override def renderMicroFace(
+      pos: Vector3,
+      pass: Int,
+      bounds: Cuboid6
+  ): Unit = {
+    MaterialRenderHelper
+      .start(pos, pass, new IconTransformation(icon))
+      .lighting()
+      .render()
+  }
+
+  override def isTransparent: Boolean = false
+  override def getLightValue: Int = 0
+  override def getStrength(player: EntityPlayer): Float = 1f
+  override def getLocalizedName: String = "Missing Material"
+  override def getItem: ItemStack = new ItemStack(Blocks.stone)
+  override def getCutterStrength: Int = 0
+  override def getSound: SoundType = Block.soundTypeStone
+  override def explosionResistance(entity: Entity): Float = 6f
+}

--- a/src/main/scala/codechicken/microblock/handler/packethandlers.scala
+++ b/src/main/scala/codechicken/microblock/handler/packethandlers.scala
@@ -26,7 +26,14 @@ object MicroblockCPH extends MicroblockPH with IClientPacketHandler {
       netHandler: INetHandlerPlayClient
   ) {
     packet.getType match {
-      case 1 => handleMaterialRegistration(packet, netHandler)
+      // In singleplayer the integrated server and this client share the one
+      // static registry, so the id-map packet is redundant. Skipping it avoids
+      // rebuilding (clearing) the shared maps on the netty thread while the
+      // server thread reads them - the race that turned microblocks into Blood
+      // Rune slabs.
+      case 1 =>
+        if (!mc.isSingleplayer)
+          handleMaterialRegistration(packet, netHandler)
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14921

Unknown material names resolved to id 0 (Blood Rune in GTNH), and in
singleplayer the client handshake cleared the shared name map on the
netty thread while the integrated server read it, so microblocks
randomly and permanently turned into Blood Rune slabs.

Resolve unknown names to a MissingMicroMaterial placeholder (vanilla
missing texture) instead of id 0, and skip the redundant id-map
handshake on the integrated client so it no longer clears the shared
maps mid-read.