### PR TITLE
Add postea transformer for microblock items

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,6 +3,7 @@
 dependencies {
     implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.12:dev")
     compileOnly("com.github.GTNewHorizons:Angelica:2.1.19:dev")
+    compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") {transitive = false}
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'CodeChickenCore'
     }

--- a/src/main/scala/codechicken/microblock/compat/ItemMicroPartTransformer.java
+++ b/src/main/scala/codechicken/microblock/compat/ItemMicroPartTransformer.java
@@ -1,0 +1,29 @@
+package codechicken.microblock.compat;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.gtnewhorizons.postea.api.IItemStackTransformationHandler;
+
+import codechicken.microblock.MicroMaterialRegistry;
+
+public class ItemMicroPartTransformer implements IItemStackTransformationHandler {
+
+    @Override
+    public boolean apply(String originalItemId, NBTTagCompound stackTag) {
+        if (!stackTag.hasKey("tag")) return false;
+        NBTTagCompound tag = stackTag.getCompoundTag("tag");
+        if (!tag.hasKey("mat")) return false;
+
+        String matName = tag.getString("mat");
+
+        // Goes through the remap layer, which is private
+        int remappedId = MicroMaterialRegistry.materialID(matName);
+        String remappedName = MicroMaterialRegistry.materialName(remappedId);
+
+        if (remappedName.equals(matName)) return false;
+
+        tag.setString("mat", remappedName);
+        stackTag.setTag("tag", tag);
+        return true;
+    }
+}

--- a/src/main/scala/codechicken/microblock/compat/PosteaCompat.java
+++ b/src/main/scala/codechicken/microblock/compat/PosteaCompat.java
@@ -1,0 +1,11 @@
+package codechicken.microblock.compat;
+
+import com.gtnewhorizons.postea.api.ItemStackReplacementManager;
+
+public class PosteaCompat {
+
+    public static void registerTransformers() {
+        ItemStackReplacementManager
+                .addTransformationHandler("ForgeMicroblock:microblock", new ItemMicroPartTransformer());
+    }
+}

--- a/src/main/scala/codechicken/microblock/handler/proxies.scala
+++ b/src/main/scala/codechicken/microblock/handler/proxies.scala
@@ -16,6 +16,7 @@ import net.minecraftforge.oredict.OreDictionary
 import net.minecraft.item.ItemStack
 import net.minecraftforge.oredict.ShapedOreRecipe
 import codechicken.lib.packet.PacketCustom
+import codechicken.microblock.compat.PosteaCompat
 import cpw.mods.fml.common.Loader
 import cpw.mods.fml.common.registry.GameRegistry
 import net.minecraft.client.renderer.RenderBlocks
@@ -110,6 +111,9 @@ class MicroblockProxy_serverImpl {
       MicroblockSPH.registryChannel,
       MicroblockSPH
     )
+    if (Loader.isModLoaded("postea")) {
+      PosteaCompat.registerTransformers()
+    }
   }
 }
 


### PR DESCRIPTION
Adds a postea transformer targeting microblocks that uses FMP's remap system to fix mat ids. Tested with Extra Utilities -> Utilities in Excess FMP remaps.

This makes transitions more seamless by not leaving players with confusing remapped items that don't stack because they still have the old material id.