### PR TITLE
Fix TE interceptor for CC

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,6 +2,7 @@
 
 dependencies {
     implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.12:dev")
+    compileOnly("com.cardinalstar.cubicchunks:CubicChunks1710:v0.1.7-alpha:dev")
     compileOnly("com.github.GTNewHorizons:Angelica:2.1.19:dev")
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") {transitive = false}
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev") {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,12 +1,12 @@
 // Add your dependencies here
 
 dependencies {
-    implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.12:dev")
-    compileOnly("com.cardinalstar.cubicchunks:CubicChunks1710:v0.1.7-alpha:dev")
-    compileOnly("com.github.GTNewHorizons:Angelica:2.1.19:dev")
+    implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.16:dev")
+    compileOnly("com.cardinalstar.cubicchunks:CubicChunks1710:v0.1.8-alpha:dev")
+    compileOnly("com.github.GTNewHorizons:Angelica:2.1.54:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.174:dev")
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") {transitive = false}
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev") {
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'CodeChickenCore'
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation("com.github.GTNewHorizons:CodeChickenCore:1.4.12:dev")
     compileOnly("com.cardinalstar.cubicchunks:CubicChunks1710:v0.1.7-alpha:dev")
     compileOnly("com.github.GTNewHorizons:Angelica:2.1.19:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Hodgepodge:2.7.174:dev")
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") {transitive = false}
     devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'CodeChickenCore'

--- a/src/main/scala/codechicken/multipart/MultipartGenerator.scala
+++ b/src/main/scala/codechicken/multipart/MultipartGenerator.scala
@@ -122,9 +122,14 @@ object MultipartGenerator extends ScratchBitSet {
     * adding it to the tick list
     */
   def silentAddTile(world: World, pos: BlockCoord, tile: TileEntity) {
+    tile.xCoord = pos.x;
+    tile.yCoord = pos.y;
+    tile.zCoord = pos.z;
+
     val chunk = world.getChunkFromBlockCoords(pos.x, pos.z)
-    if (chunk != null)
-      chunk.func_150812_a(pos.x & 15, pos.y, pos.z & 15, tile)
+    if (chunk != null) {
+      chunk.addTileEntity(tile)
+    }
   }
 
   /** Check if tile satisfies all the interfaces required by parts. If not,

--- a/src/main/scala/codechicken/multipart/handler/CubicChunksCompat.scala
+++ b/src/main/scala/codechicken/multipart/handler/CubicChunksCompat.scala
@@ -13,16 +13,6 @@ object CubicChunksCompat {
     val cube = event.cube
     val world = event.world
 
-    val iter = cube.cubeTileEntityMap.entrySet().iterator()
-
-    while (iter.hasNext) {
-      val e = iter.next();
-
-      val converted = MultipartSaveLoad.convertTileForCube(world, e.getValue)
-      if (converted != e.getValue) {
-        if (converted != null) e.setValue(converted)
-        else cube.cubeTileEntityMap.remove(e.getKey)
-      }
-    }
+    MultipartSaveLoad.loadTiles(world, cube.cubeTileEntityMap)
   }
 }

--- a/src/main/scala/codechicken/multipart/handler/CubicChunksCompat.scala
+++ b/src/main/scala/codechicken/multipart/handler/CubicChunksCompat.scala
@@ -9,7 +9,7 @@ object CubicChunksCompat {
   def init(): Unit = MinecraftForge.EVENT_BUS.register(this)
 
   @SubscribeEvent(priority = EventPriority.HIGHEST)
-  def onTileEntitiesLoad(event: CubeEvent.TileEntitiesLoad): Unit = {
+  def onTileEntitiesLoad(event: CubeEvent.DataLoad): Unit = {
     val cube = event.cube
     val world = event.world
 

--- a/src/main/scala/codechicken/multipart/handler/CubicChunksCompat.scala
+++ b/src/main/scala/codechicken/multipart/handler/CubicChunksCompat.scala
@@ -1,0 +1,28 @@
+package codechicken.multipart.handler
+
+import com.cardinalstar.cubicchunks.api.event.CubeEvent
+import cpw.mods.fml.common.eventhandler.{EventPriority, SubscribeEvent}
+import net.minecraftforge.common.MinecraftForge
+import scala.collection.JavaConversions._
+
+object CubicChunksCompat {
+  def init(): Unit = MinecraftForge.EVENT_BUS.register(this)
+
+  @SubscribeEvent(priority = EventPriority.HIGHEST)
+  def onTileEntitiesLoad(event: CubeEvent.TileEntitiesLoad): Unit = {
+    val cube = event.cube
+    val world = event.world
+
+    val iter = cube.cubeTileEntityMap.entrySet().iterator()
+
+    while (iter.hasNext) {
+      val e = iter.next();
+
+      val converted = MultipartSaveLoad.convertTileForCube(world, e.getValue)
+      if (converted != e.getValue) {
+        if (converted != null) e.setValue(converted)
+        else cube.cubeTileEntityMap.remove(e.getKey)
+      }
+    }
+  }
+}

--- a/src/main/scala/codechicken/multipart/handler/MultipartEventHandler.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartEventHandler.scala
@@ -18,7 +18,11 @@ import scala.collection.JavaConverters._
 object MultipartEventHandler {
   @SubscribeEvent(priority = EventPriority.HIGHEST)
   def tileEntityLoad(event: ChunkDataEvent.Load) {
-    MultipartSaveLoad.loadTiles(event.getChunk.worldObj, event.getChunk.chunkTileEntityMap.asInstanceOf[java.util.Map[ChunkPosition, TileEntity]])
+    MultipartSaveLoad.loadTiles(
+      event.getChunk.worldObj,
+      event.getChunk.chunkTileEntityMap
+        .asInstanceOf[java.util.Map[ChunkPosition, TileEntity]]
+    )
   }
 
   @SubscribeEvent

--- a/src/main/scala/codechicken/multipart/handler/MultipartEventHandler.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartEventHandler.scala
@@ -1,30 +1,24 @@
 package codechicken.multipart.handler
 
-import codechicken.multipart.{
-  TileCache,
-  TileMultipart,
-  MultiPartRegistry,
-  BlockMultipart
-}
+import codechicken.multipart.{BlockMultipart, TileCache, TileMultipart}
 import cpw.mods.fml.common.eventhandler.{EventPriority, SubscribeEvent}
-import net.minecraft.server.MinecraftServer
-import codechicken.lib.packet.PacketCustom
-import net.minecraftforge.event.world._
-import java.util.EnumSet
-import scala.collection.JavaConverters._
-import java.util.List
-import net.minecraft.entity.player.EntityPlayerMP
-import cpw.mods.fml.relauncher.SideOnly
-import cpw.mods.fml.relauncher.Side
-import net.minecraftforge.client.event.DrawBlockHighlightEvent
-import net.minecraft.util.MovingObjectPosition
-import net.minecraft.util.MovingObjectPosition.MovingObjectType
 import cpw.mods.fml.common.gameevent.TickEvent
+import cpw.mods.fml.relauncher.{Side, SideOnly}
+import net.minecraft.entity.player.EntityPlayerMP
+import net.minecraft.server.MinecraftServer
+import net.minecraft.tileentity.TileEntity
+import net.minecraft.util.MovingObjectPosition.MovingObjectType
+import net.minecraft.world.ChunkPosition
+import net.minecraftforge.client.event.DrawBlockHighlightEvent
+import net.minecraftforge.event.world._
+
+import java.util.List
+import scala.collection.JavaConverters._
 
 object MultipartEventHandler {
   @SubscribeEvent(priority = EventPriority.HIGHEST)
   def tileEntityLoad(event: ChunkDataEvent.Load) {
-    MultipartSaveLoad.loadTiles(event.getChunk)
+    MultipartSaveLoad.loadTiles(event.getChunk.worldObj, event.getChunk.chunkTileEntityMap.asInstanceOf[java.util.Map[ChunkPosition, TileEntity]])
   }
 
   @SubscribeEvent

--- a/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
@@ -2,14 +2,16 @@ package codechicken.multipart.handler
 
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.nbt.NBTTagCompound
+
 import java.util.Map
-import net.minecraft.world.chunk.Chunk
 import net.minecraft.world.ChunkPosition
 import codechicken.multipart.{MultipartHelper, TileMultipart}
 import codechicken.lib.asm.ObfMapping
 import net.minecraft.world.World
+
 import scala.collection.mutable
 import codechicken.multipart.MultipartHelper.IPartTileConverter
+
 import scala.collection.JavaConversions._
 
 /** Hack due to lack of TileEntityLoadEvent in forge
@@ -58,38 +60,9 @@ object MultipartSaveLoad {
     field.get(null).asInstanceOf[Map[Class[_ <: TileEntity], String]]
   }
 
-  def convertTileForCube(world: World, tile: TileEntity): TileEntity = {
+  def loadTiles(world: World, tiles: Map[ChunkPosition, TileEntity]) {
     loadingWorld = world
-    tile match {
-      case s: TileNBTContainer if s.tag.getString("id") == "savedMultipart" =>
-        val newTile = TileMultipart.createFromNBT(s.tag)
-        if (newTile != null) {
-          newTile.setWorldObj(world)
-          newTile.validate()
-        }
-        newTile
-      case t =>
-        converters.find(_.canConvert(t)) match {
-          case Some(c) =>
-            val parts = c.convert(t)
-            if (parts.isEmpty) null
-            else {
-              val newTile = MultipartHelper.createTileFromParts(parts)
-              if (newTile != null) {
-                newTile.setWorldObj(world)
-                newTile.validate()
-              }
-              newTile
-            }
-          case None => tile
-        }
-    }
-  }
-
-  def loadTiles(chunk: Chunk) {
-    loadingWorld = chunk.worldObj
-    val iterator = chunk.chunkTileEntityMap
-      .asInstanceOf[Map[ChunkPosition, TileEntity]]
+    val iterator = tiles
       .entrySet
       .iterator
     while (iterator.hasNext) {

--- a/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
@@ -58,6 +58,34 @@ object MultipartSaveLoad {
     field.get(null).asInstanceOf[Map[Class[_ <: TileEntity], String]]
   }
 
+  def convertTileForCube(world: World, tile: TileEntity): TileEntity = {
+    loadingWorld = world
+    tile match {
+      case s: TileNBTContainer if s.tag.getString("id") == "savedMultipart" =>
+        val newTile = TileMultipart.createFromNBT(s.tag)
+        if (newTile != null) {
+          newTile.setWorldObj(world)
+          newTile.validate()
+        }
+        newTile
+      case t =>
+        converters.find(_.canConvert(t)) match {
+          case Some(c) =>
+            val parts = c.convert(t)
+            if (parts.isEmpty) null
+            else {
+              val newTile = MultipartHelper.createTileFromParts(parts)
+              if (newTile != null) {
+                newTile.setWorldObj(world)
+                newTile.validate()
+              }
+              newTile
+            }
+          case None => tile
+        }
+    }
+  }
+
   def loadTiles(chunk: Chunk) {
     loadingWorld = chunk.worldObj
     val iterator = chunk.chunkTileEntityMap

--- a/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
+++ b/src/main/scala/codechicken/multipart/handler/MultipartSaveLoad.scala
@@ -62,9 +62,7 @@ object MultipartSaveLoad {
 
   def loadTiles(world: World, tiles: Map[ChunkPosition, TileEntity]) {
     loadingWorld = world
-    val iterator = tiles
-      .entrySet
-      .iterator
+    val iterator = tiles.entrySet.iterator
     while (iterator.hasNext) {
       val e = iterator.next
       var next = false

--- a/src/main/scala/codechicken/multipart/handler/proxies.scala
+++ b/src/main/scala/codechicken/multipart/handler/proxies.scala
@@ -13,7 +13,7 @@ import codechicken.lib.packet.PacketCustom
 import net.minecraft.world.ChunkCoordIntPair
 import codechicken.lib.vec.BlockCoord
 import codechicken.lib.world.{TileChunkLoadHook, WorldExtensionManager}
-import cpw.mods.fml.common.FMLCommonHandler
+import cpw.mods.fml.common.{FMLCommonHandler, Loader}
 import cpw.mods.fml.common.registry.GameRegistry
 import net.minecraft.block.Block
 import org.apache.logging.log4j.Logger
@@ -90,6 +90,8 @@ class MultipartProxy_serverImpl {
     TileChunkLoadHook.init()
 
     MultipartCompatiblity.load()
+    if (Loader.isModLoaded("cubicchunks"))
+      CubicChunksCompat.init()
   }
 
   def onTileClassBuilt(t: Class[_ <: TileEntity]) {


### PR DESCRIPTION
## Summary
FMP intercepts the tile entities in a chunk before they are loaded, to swap out its fake wrapper TE with a dynamic TE class (since it generates classes at runtime :doom:). CC doesn't store tiles in chunks anymore, so this code had to be adapted to instead intercept cube loads.

depends on: https://github.com/GTNewHorizons/CubicChunks1710/pull/82

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
