### PR TITLE
Apply mining speed for all FMP blocks

### DIFF
--- a/src/main/scala/codechicken/multipart/BlockMultipart.scala
+++ b/src/main/scala/codechicken/multipart/BlockMultipart.scala
@@ -289,7 +289,7 @@ class BlockMultipart extends Block(new Material(MapColor.stoneColor)) {
     val tile = getTile(world, x, y, z)
     if (hit != null && tile != null) {
       val (index, mop) = reduceMOP(hit)
-      return tile.partList(index).getStrength(mop, player) / breakSpeed / 30f
+      return breakSpeed * tile.partList(index).getStrength(mop, player) / 30f
     }
 
     return 1 / 100f

--- a/src/main/scala/codechicken/multipart/BlockMultipart.scala
+++ b/src/main/scala/codechicken/multipart/BlockMultipart.scala
@@ -284,11 +284,12 @@ class BlockMultipart extends Block(new Material(MapColor.stoneColor)) {
       y: Int,
       z: Int
   ): Float = {
+    val breakSpeed = player.getBreakSpeed(this, true, world.getBlockMetadata(x, y, z), x, y, z)
     val hit = RayTracer.retraceBlock(world, player, x, y, z)
     val tile = getTile(world, x, y, z)
     if (hit != null && tile != null) {
       val (index, mop) = reduceMOP(hit)
-      return tile.partList(index).getStrength(mop, player) / 30f
+      return tile.partList(index).getStrength(mop, player) / breakSpeed / 30f
     }
 
     return 1 / 100f

--- a/src/main/scala/codechicken/multipart/BlockMultipart.scala
+++ b/src/main/scala/codechicken/multipart/BlockMultipart.scala
@@ -284,7 +284,8 @@ class BlockMultipart extends Block(new Material(MapColor.stoneColor)) {
       y: Int,
       z: Int
   ): Float = {
-    val breakSpeed = player.getBreakSpeed(this, true, world.getBlockMetadata(x, y, z), x, y, z)
+    val breakSpeed =
+      player.getBreakSpeed(this, true, world.getBlockMetadata(x, y, z), x, y, z)
     val hit = RayTracer.retraceBlock(world, player, x, y, z)
     val tile = getTile(world, x, y, z)
     if (hit != null && tile != null) {


### PR DESCRIPTION
## Summary
Apply mining speed for all FMP blocks. Previously all mining speed buff is completely ignored, including haste potions and efficiency pickaxe. Now they are applied, and the speed will be the same as original if the player mine with bare hand.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
